### PR TITLE
Feature/scrollout

### DIFF
--- a/src/components/Atoms/Tile/Tile.style.js
+++ b/src/components/Atoms/Tile/Tile.style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const Container = styled('div')`
   background-color: #edb089;
   border: dashed 5px white;
-  height: 300px;
+  min-height: 300px;
   width: 40%;
   display: flex;
   flex-direction: column;
@@ -23,7 +23,7 @@ export const Info = styled('p')`
 `;
 
 export const Picture = styled('img')`
-  height: 100%;
+  width: 100%;
 `;
 
 export const PictureWrapper = styled('div')`

--- a/src/components/Molecules/Scrollout/Scrollout.jsx
+++ b/src/components/Molecules/Scrollout/Scrollout.jsx
@@ -1,0 +1,63 @@
+import React, { createRef, useState, useEffect } from 'react';
+import * as S from './Scrollout.style';
+import { Tab } from '../../Atoms';
+
+const Scrollout = ({ title, Content, rotation }) => {
+  const [open, setOpen] = useState(false);
+  const [distance, setDistance] = useState(0);
+  const wrapperRef = createRef();
+  const containerRef = createRef();
+  useEffect(() => {
+    if (
+      (rotation > 89 && rotation < 180) ||
+      (rotation > 269 && rotation < 360)
+    ) {
+      setDistance(wrapperRef.current.scrollWidth);
+    } else {
+      setDistance(wrapperRef.current.scrollHeight);
+    }
+  }, []);
+  useEffect(() => {
+    console.log('it has changed');
+    if (
+      open &&
+      containerRef &&
+      containerRef.current &&
+      containerRef.current.scrollHeight
+    ) {
+      console.log(containerRef.current.scrollHeight);
+      for (let i = 10; i < 2000; i += 10) {
+        setTimeout(() => {
+          window.scrollTo(
+            window.scrollX,
+            window.innerHeight + containerRef.current.scrollHeight,
+          );
+          console.log(containerRef.current.scrollHeight);
+        }, i);
+      }
+    }
+  }, [open]); // eslint-disable-line prettier/prettier
+
+  return (
+    <S.Container
+      open={open}
+      distance={distance}
+      rotation={rotation}
+      ref={containerRef}
+    >
+      <S.TabWrapper>
+        <Tab title={title} setOpen={setOpen} open={open} rotation={rotation} />
+      </S.TabWrapper>
+      <S.ContentWrapper
+        ref={wrapperRef}
+        open={open}
+        distance={distance}
+        rotation={rotation}
+      >
+        <Content />
+      </S.ContentWrapper>
+    </S.Container>
+  );
+};
+
+export default Scrollout;

--- a/src/components/Molecules/Scrollout/Scrollout.stories.jsx
+++ b/src/components/Molecules/Scrollout/Scrollout.stories.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import Scrollout from './Scrollout';
+
+export default {
+  title: 'Molecules/Scrollout',
+  component: Scrollout,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+};
+
+const Template = args => (
+  <div style={{ height: '800px', width: '800px', backgroundColor: 'black' }}>
+    <Rollout {...args} />
+  </div>
+);
+
+const ExampleContent = () => (
+  <div style={{ height: '400px', width: '600px' }}>
+    <p>There are things that you needed to say</p>
+  </div>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  title: 'About Page',
+  Content: ExampleContent,
+};
+
+export const Top = Template.bind({});
+Top.args = {
+  title: 'About Page',
+  Content: ExampleContent,
+  rotation: 180,
+};
+
+export const Left = Template.bind({});
+Left.args = {
+  title: 'About Page',
+  Content: ExampleContent,
+  rotation: 90,
+};
+
+export const Right = Template.bind({});
+Right.args = {
+  title: 'About Page',
+  Content: ExampleContent,
+  rotation: 270,
+};

--- a/src/components/Molecules/Scrollout/Scrollout.style.js
+++ b/src/components/Molecules/Scrollout/Scrollout.style.js
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+
+const setDimensions = rotation => {
+  if (rotation > 269 && rotation < 360) {
+    // right hand side of the screen
+    return `
+    right: calc(100vw - 64px);
+    display: flex;
+    flex-direction: row;
+      `;
+  }
+  if (rotation > 179) {
+    // top of the screen
+    return `
+    bottom: calc(100vh - 64px);
+    display: flex;
+    flex-direction: column-reverse;
+      `;
+  }
+  if (rotation > 89) {
+    // left hand side of the screen
+    return `
+    left: calc(100vh - 64px);
+    display: flex;
+    flex-direction: row-reverse;
+    
+      `;
+  }
+  // bottom of the screen
+  return `
+  top: calc(100vh - 64px);
+  display: flex;
+  flex-direction: column;
+      `;
+};
+
+const setTransition = (rotation, distance, open) => {
+  if ((rotation > 89 && rotation < 180) || (rotation > 269 && rotation < 360)) {
+    return `
+    transition: width ease 2s;
+    width: ${open ? `${distance}px` : `0px`};
+      `;
+  }
+  return `
+  transition: height ease 2s;
+  height: ${open ? `${distance}px` : `0px`};
+      `;
+};
+
+export const Container = styled('div')`
+  position: absolute;
+  justify-content: flex-end;
+  ${({ rotation }) => setDimensions(rotation)}
+`;
+
+export const TabWrapper = styled('div')`
+  position: relative;
+`;
+
+export const ContentWrapper = styled('div')`
+  ${({ rotation, distance, open }) => setTransition(rotation, distance, open)}
+  overflow: hidden;
+  background-color: rgba(237, 176, 137, 0.5);
+`;

--- a/src/components/Molecules/index.js
+++ b/src/components/Molecules/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 export { default as HeaderBar } from './HeaderBar/HeaderBar';
 export { default as Rollout } from './Rollout/Rollout';
+export { default as Scrollout } from './Scrollout/Scrollout';

--- a/src/pages/Main/Main.jsx
+++ b/src/pages/Main/Main.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import * as S from './Main.style';
-import { Avatar, Button, Rollout, Tile } from '../../components';
+import { Avatar, Button, Rollout, Scrollout, Tile } from '../../components';
 import Me from '../../assets/me.jpg';
 import { data } from './data';
 
@@ -51,7 +51,7 @@ const Main = () => {
         <Avatar image={Me} />
         <S.Title>Millisande</S.Title>
       </S.Content>
-      <Rollout title='Portfolio' Content={Content} />
+      <Scrollout title='Portfolio' Content={Content} />
       <Rollout title='About' Content={SideContent} rotation={90} top='58px' />
     </S.Container>
   );

--- a/src/pages/Main/Main.style.js
+++ b/src/pages/Main/Main.style.js
@@ -30,13 +30,16 @@ export const Tip = styled('p')`
 
 export const About = styled('div')`
   height: 400px;
-  min-width: 450px;
-  width: 35vh;
+  max-width: 450px;
+  width: 45vw;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   overflow: hidden;
+  @media (max-width: 550px) {
+    width: calc(100vw - 58px);
+  }
 `;
 
 export const AboutWrapper = styled('div')`


### PR DESCRIPTION
- scrollout instead of rollout, it meant using a for loop which seems old fashioned but it actually works surprisingly well, and I couldn't find a better solution online
- images on portfolio tiles now standardised by width instead of height
- tiles have a min-height rather than a set height so that they extend to allow for more text when on smaller screens
- about panel will show all text except when the screen is around 527px wide and I have deprioritised fixing it 